### PR TITLE
Compiler Vars Tweak

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JNA"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="C:/Users/Owner/Desktop/ENIGMA/enigma-dev/plugins/shared/jna.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Owner/Desktop/enigma-dev/plugins/shared/jna.jar"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/LateralGM"/>
 	<classpathentry kind="src" path=""/>
 	<classpathentry kind="output" path=""/>

--- a/description.jardesc
+++ b/description.jardesc
@@ -1,34 +1,34 @@
-<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <jardesc>
-    <jar path="lgmplugin/enigma.jar"/>
-    <options buildIfNeeded="true" compress="true" descriptionLocation="/lgmplugin/description.jardesc" exportErrors="true" exportWarnings="true" includeDirectoryEntries="false" overwrite="true" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>
+    <jar path="Enigma/enigma.jar"/>
+    <options buildIfNeeded="true" compress="true" descriptionLocation="/Enigma/description.jardesc" exportErrors="true" exportWarnings="true" includeDirectoryEntries="false" overwrite="true" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>
     <storedRefactorings deprecationInfo="true" structuralOnly="false"/>
     <selectedProjects/>
-    <manifest generateManifest="false" manifestLocation="/lgmplugin/META-INF/MANIFEST.MF" manifestVersion="1.0" reuseManifest="false" saveManifest="false" usesManifest="true">
+    <manifest generateManifest="false" manifestLocation="/Enigma/META-INF/MANIFEST.MF" manifestVersion="1.0" reuseManifest="false" saveManifest="false" usesManifest="true">
         <sealing sealJar="false">
             <packagesToSeal/>
             <packagesToUnSeal/>
         </sealing>
     </manifest>
     <selectedElements exportClassFiles="true" exportJavaFiles="true" exportOutputFolder="false">
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.frames"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.other"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.util"/>
-        <file path="/lgmplugin/.classpath"/>
-        <file path="/lgmplugin/description.jardesc"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.resources"/>
-        <folder path="/lgmplugin/META-INF"/>
-        <file path="/lgmplugin/COPYING"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.messages"/>
-        <file path="/lgmplugin/Makefile"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.utility"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.file"/>
-        <file path="/lgmplugin/LICENSE"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.sub"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma"/>
-        <file path="/lgmplugin/.gitignore"/>
-        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend"/>
-        <file path="/lgmplugin/README.md"/>
-        <file path="/lgmplugin/.project"/>
+        <file path="/Enigma/.classpath"/>
+        <file path="/Enigma/description.jardesc"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.utility"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.file"/>
+        <folder path="/Enigma/META-INF"/>
+        <file path="/Enigma/COPYING"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.sub"/>
+        <file path="/Enigma/Makefile"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.util"/>
+        <file path="/Enigma/LICENSE"/>
+        <file path="/Enigma/.gitignore"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.messages"/>
+        <file path="/Enigma/README.md"/>
+        <file path="/Enigma/.project"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.other"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.frames"/>
+        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.resources"/>
     </selectedElements>
 </jardesc>

--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -276,6 +276,7 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 				{
 				File gccey = new File(new File("Compilers",TargetHandler.getOS()),"gcc.ey"); //$NON-NLS-1$ //$NON-NLS-2$
 				YamlNode n = YamlParser.parse(gccey);
+				n = (YamlNode) n.getM("Make-Vars"); //or OOB  //$NON-NLS-1$
 				make = n.getMC("Make"); //or OOB  //$NON-NLS-1$
 				tcpath = n.getMC("TCPath",new String()); //$NON-NLS-1$
 				path = n.getMC("Path",new String()); //$NON-NLS-1$

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -49,8 +49,6 @@ import java.util.WeakHashMap;
 import java.util.zip.DeflaterOutputStream;
 
 import javax.swing.JOptionPane;
-import javax.xml.bind.DatatypeConverter;
-
 import org.enigma.backend.EnigmaStruct;
 import org.enigma.backend.other.Constant;
 import org.enigma.backend.other.Extension;
@@ -195,13 +193,22 @@ public final class EnigmaWriter {
 		o.lastTileId = i.lastTileId;
 	}
 
-	// make sure we replace these md5 sum'd icons if they are in anybodies
-	// project
-	byte[][] icoBlackList = new byte[][] {
-			DatatypeConverter
-					.parseHexBinary("1f742f5c692b84bbe6e522233555e291"),
-			DatatypeConverter
-					.parseHexBinary("08aa73a35d0c8f45bcad79b0635007de") };
+	// The following array of byte arrays contains md5 checksums of GameMaker-default game
+	// icons and logos. These md5 checksums are used to remove these specific graphics to ensure
+	// that the default graphics (which are Yoyo IP and GM-specific) does not accidentally persist
+	// into an ENIGMA game file/binary.
+	private byte[][] icoBlackList = new byte[][] {
+		{
+		0x1F, 0x74, 0x2F, 0x5C, 0x69, 0x2B, (byte) 0x84,
+		(byte) 0xBB, (byte) 0xE6, (byte) 0xE5, 0x22, 0x23,
+		0x35, 0x55, (byte) 0xE2, (byte) 0x91 
+		},
+		{
+		0x08, (byte) 0xAA, 0x73, (byte) 0xA3, 0x5D, 0x0C,
+		(byte) 0x8F, 0x45, (byte) 0xBC, (byte) 0xAD, 0x79,
+		(byte) 0xB0, 0x63, 0x50, 0x07, (byte) 0xDE
+		},
+	};
 
 	protected void populateInformation() {
 		org.lateralgm.resources.GameInformation ig = i.gameInfo;
@@ -306,7 +313,7 @@ public final class EnigmaWriter {
 				File f = File.createTempFile("egm_ico", ".ico");
 
 				// if the icon has been black listed, replace it with the
-				// defualt one
+				// default one
 				byte[] hash = ico.getDigest("MD5");
 				for (byte[] blhash : icoBlackList) {
 					if (Arrays.equals(hash, blhash)) {

--- a/org/enigma/TargetHandler.java
+++ b/org/enigma/TargetHandler.java
@@ -274,14 +274,15 @@ public final class TargetHandler
 			try
 				{
 				YamlNode node = YamlParser.parse(file);
+				YamlNode exeVarsNode = (YamlNode) node.getM("EXE-Vars");
 
 				TargetSelection ps = new TargetSelection();
 				ps.id = ey.substring(0,ey.length() - 3);
 				ps.name = node.getMC("Name"); //$NON-NLS-1$
 				ps.desc = node.getMC("Description",null); //$NON-NLS-1$
 				ps.auth = node.getMC("Maintainer",null); //$NON-NLS-1$
-				ps.ext = node.getMC("Build-Extension",null); //$NON-NLS-1$
-				ps.outputexe = node.getMC("Run-output",null); //$NON-NLS-1$
+				ps.ext = exeVarsNode.getMC("Build-Extension",null); //$NON-NLS-1$
+				ps.outputexe = exeVarsNode.getMC("Run-output",null); //$NON-NLS-1$
 				ps.depends = new HashMap<String,Set<String>>();
 				Set<String> target = new HashSet<String>();
 				String targplat = node.getMC("Target-platform",null); //$NON-NLS-1$


### PR DESCRIPTION
This pull request addresses the issues raised in #61 that resulted from `cumpule` pull request by fundies on the main repo: https://github.com/enigma-dev/enigma-dev/pull/1278

This also separately addresses the issues raised in #62 by hard coding the byte arrays of the default GameMaker game icons (thanks to Josh) and removing the dependency on DatatypeConverter (now deprecated in Java 9).

I have a working jar ready to be uploaded to the releases page whenever this is merged.
Download: [enigmajar.zip](https://github.com/enigma-dev/lgmplugin/files/2116091/enigmajar.zip)
MD5 Checksum: 6cebf64397b48a7abd9c65d1b23f8de0
