### PR TITLE
Eyaml/Compiler Targets Stability

### DIFF
--- a/org/enigma/TargetHandler.java
+++ b/org/enigma/TargetHandler.java
@@ -303,9 +303,11 @@ public final class TargetHandler
 					ps.outputexe = exeVarsNode.getMC("Run-output",null); //$NON-NLS-1$
 					}
 				catch (IndexOutOfBoundsException e)
-					{ // there was no "EXE-Vars" key, which is optional
-					ps.ext = null;
-					ps.outputexe = null;
+					{
+					// there was no "EXE-Vars" key, which is optional
+					// but still check under the old location
+					ps.ext = node.getMC("Build-Extension",null); //$NON-NLS-1$
+					ps.outputexe = node.getMC("Run-output",null); //$NON-NLS-1$
 					}
 
 				// only add the target if there were no errors


### PR DESCRIPTION
This one is for fundies and continues from #63 with additional stability. These changes will keep the plugin in a stable state if loading its target compilers from their ey files fails. I was able to test this very easy, under the current revision, if I simply added an empty file called "test.ey" to `enigma-dev/Compilers/Windows` I would be met with the following error:
```
Caused by: java.util.NoSuchElementException: No line found
        at java.base/java.util.Scanner.nextLine(Unknown Source)
        at org.enigma.file.YamlParser.parse(YamlParser.java:206)
        at org.enigma.file.YamlParser.parse(YamlParser.java:189)
        at org.enigma.TargetHandler.findCompilers(TargetHandler.java:276)
        at org.enigma.TargetHandler.load(TargetHandler.java:57)
        at org.enigma.TargetHandler.<clinit>(TargetHandler.java:51)
        ... 15 more
```

After this error, the plugin is put in an unusable state and the IDE does not appear (the process must be killed). Believe it or not, the handling of other ey files for systems and extensions was already dealing with obscure ey files just fine without crashing the plugin.

This pull request puts a safety net around the entire static initializer, ensuring that the plugin will still load and the IDE will open, while also ensuring that the user is stilled informed of the issue. Next, this pr makes the "EXE-Vars" key optional, since all of its subkeys were actually optional before #63 (because `.getMC` was used to get them with null as the second parameter). Finally, only when the entire ey file is read successfully, with all required keys present, is the target added to available selections.

I have prepared a new jar ready for release after this pull request is merged.
Download: [enigma-compiler-stability-jar.zip](https://github.com/enigma-dev/lgmplugin/files/2125525/enigma-compiler-stability-jar.zip)
md5sum: bfd13880fd7dd9799ef635f74f9b3782

With this updated plugin, and creating an empty "test.ey" as I described above, I am still presented with the same error message (only less verbose from not being wrapped and caught by the uncaught handler). However, the plugin now remains usable and I can still compile games.
![Plugin Stable After Target Selection](https://user-images.githubusercontent.com/3212801/41747711-ef8f27c8-757c-11e8-880b-6f2c338b07ea.png)
I also tried reproducing some other eyaml mistakes, like having keys but with the required prefix missing. This also results in more stable behavior whereby the error is shown, but the plugin remains usable.
![Plugin Stable Despite Missing Eyaml Prefix](https://user-images.githubusercontent.com/3212801/41748506-30cb1f00-7580-11e8-91e0-b897be42216c.png)

