### PR TITLE
Use Fixed 96 DPI Font Scaling In Games

### DIFF
--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -620,6 +620,14 @@ public final class EnigmaWriter {
 	}
 
 	protected void populateFonts() {
+		// no dpi scaling, since 96 is the Windows default
+		// it is the default for GM8, GMS1.4, and GMS2 and
+		// is independent of the current monitor or IDE settings
+		final int screenRes = 96;
+
+		// the size of the default font
+		final int defaultFontSize = 12;
+
 		int size = i.resMap.getList(org.lateralgm.resources.Font.class).size() + 1;
 		o.fontCount = size;
 
@@ -628,12 +636,12 @@ public final class EnigmaWriter {
 
 		// Populate the default font, called "EnigmaDefault", id -1
 		java.awt.Font iF = new java.awt.Font(java.awt.Font.DIALOG,
-				java.awt.Font.PLAIN, 12);
+				java.awt.Font.PLAIN, (int) Math.round(defaultFontSize * screenRes / 72.0));
 		Font oF = ofl[0];
 		oF.name = "EnigmaDefault"; //$NON-NLS-1$
 		oF.id = -1;
 		oF.fontName = iF.getFontName();
-		oF.size = iF.getSize();
+		oF.size = defaultFontSize;
 		oF.bold = false;
 		oF.italic = false;
 		GlyphRange.ByReference oFglyphranges = new GlyphRange.ByReference();
@@ -663,8 +671,6 @@ public final class EnigmaWriter {
 			of.bold = ifont.get(PFont.BOLD);
 			of.italic = ifont.get(PFont.ITALIC);
 
-			// no dpi scaling, since 72 is used by GM and ENIGMA's TTF extension
-			final int screenRes = 72;
 			GlyphRange.ByReference glyphranges = new GlyphRange.ByReference();
 			if (ifont.characterRanges.size() > 0) {
 				GlyphRange[] ofgrl = (GlyphRange[]) glyphranges

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -663,11 +663,8 @@ public final class EnigmaWriter {
 			of.bold = ifont.get(PFont.BOLD);
 			of.italic = ifont.get(PFont.ITALIC);
 
-			int screenRes;
-			if (GraphicsEnvironment.isHeadless())
-				screenRes = 72;
-			else
-				screenRes = Toolkit.getDefaultToolkit().getScreenResolution();
+			// no dpi scaling, since 72 is used by GM and ENIGMA's TTF extension
+			final int screenRes = 72;
 			GlyphRange.ByReference glyphranges = new GlyphRange.ByReference();
 			if (ifont.characterRanges.size() > 0) {
 				GlyphRange[] ofgrl = (GlyphRange[]) glyphranges


### PR DESCRIPTION
I've documented this issue thoroughly in #60. This pull request changes the plugin to use a fixed 96 dpi for all font textures it creates. This is the same DPI Windows uses by default, and extension GM8, GMS1.4, and GMS2 as I will later demonstrate.

Fundies TTF extension I noticed used 72 dpi, so I may later need to also correct it and run a comparison. However, that applies to the behavior of `font_add` not the IDE populated fonts.
https://github.com/enigma-dev/enigma-dev/blob/a66f43f896ab5307bcba7941b5a7db65f710e712/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp#L70

The scaling code for LGM's Font class was originally added by @stiell and I later moved it from `FontFrame.java` to `Font.java` where it exists now: https://github.com/IsmAvatar/LateralGM/commit/fef6ac1fffecc180b2ff64e8606f35f7a6071063

This change makes the plugin behave more like GM. The reason even modern GM does not scale fonts automatically to the current screen DPI, is because it makes the build less deterministic. If you design all the fonts in your game at a certain DPI, and then build it from a different computer, the old plugin would give you fonts that were a totally different size. If there is to be DPI scaling, then the game designer should create multiple fonts and design their game's UI with the DPI scaling. Perhaps later we can look at adding a game setting to change the default of 72dpi, but for now, we at least need this to get more deterministic results.

I've compiled here a comparison of GM8, GMS1.4, and ENIGMA's old and new plugin with font DPI scaling. I have prepared a GMK example which was used to create this comparison. The screenshots that you will see on the left have 150 dpi, while the screenshots on the right had me sign out and back in again after setting my display to 100dpi. Originally I thought 72 dpi was correct, but later discovered, thanks to @stiell's comment, it's actually 96 dpi and you will see below if you compare GM8 or GMS to the 96 dpi plugin side by side, ENIGMA now produces identical fonts to GM.
Download: [font-dpi-test.zip](https://github.com/enigma-dev/lgmplugin/files/2127441/font-dpi-test.zip)

**NOTE:** Please ignore any unrelated issues, such as the wrong window region scaling in ENIGMA, and focus on only the DPI issues mentioned here.
### GameMaker 8
![GM8 150 dpi](https://user-images.githubusercontent.com/3212801/41774756-0dad07f8-75ef-11e8-806d-eb6dccf87efa.png)![GM8 100 dpi](https://user-images.githubusercontent.com/3212801/41774766-17108932-75ef-11e8-9559-8cce763b712f.png)
### GameMaker: Studio v1.4
![GMS 150 dpi](https://user-images.githubusercontent.com/3212801/41774772-1d95e752-75ef-11e8-922f-b195367fad90.png)![GMS 100 dpi](https://user-images.githubusercontent.com/3212801/41774791-29179170-75ef-11e8-90b8-caa738206e07.png)
### ENIGMA Old Plugin
![ENIGMA Old 150 dpi](https://user-images.githubusercontent.com/3212801/41774797-2d92073a-75ef-11e8-8771-2bed6546f5a9.png)![ENIGMA Old 100 dpi](https://user-images.githubusercontent.com/3212801/41774804-30af571a-75ef-11e8-9cf0-abf0f3d95622.png)
### ENIGMA New Plugin With Fixed 72 DPI
![ENIGMA Fixed to 72 dpi with desktop at 150 dpi](https://user-images.githubusercontent.com/3212801/41774807-33ee7f64-75ef-11e8-9ae4-e13c9f35396a.png)![ENIGMA Fixed to 72 dpi with desktop at 100 dpi](https://user-images.githubusercontent.com/3212801/41774808-3563293a-75ef-11e8-99e3-a452800e478e.png)
### ENIGMA New Plugin With Fixed 96 DPI (this pull request)
![ENIGMA Fixed to 96 dpi with desktop at 150 dpi](https://user-images.githubusercontent.com/3212801/41776292-3107cd5e-75f5-11e8-8c26-44197a23f930.png)![ENIGMA Fixed to 96 dpi with desktop at 100 dpi](https://user-images.githubusercontent.com/3212801/41776296-33dbcc92-75f5-11e8-88e7-3ca52f5c9fb3.png)
### Side by Side With Fixed 96 DPI (this pull request)
![GM8 150 dpi](https://user-images.githubusercontent.com/3212801/41774756-0dad07f8-75ef-11e8-806d-eb6dccf87efa.png)![ENIGMA Fixed to 96 dpi with desktop at 150 dpi](https://user-images.githubusercontent.com/3212801/41776292-3107cd5e-75f5-11e8-8c26-44197a23f930.png)