### PR TITLE
Fix Include Population

### DIFF
--- a/description.jardesc
+++ b/description.jardesc
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <jardesc>
-    <jar path="Enigma/enigma.jar"/>
-    <options buildIfNeeded="true" compress="true" descriptionLocation="/Enigma/description.jardesc" exportErrors="true" exportWarnings="true" includeDirectoryEntries="false" overwrite="true" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>
+    <jar path="lgmplugin/enigma.jar"/>
+    <options buildIfNeeded="true" compress="true" descriptionLocation="/lgmplugin/description.jardesc" exportErrors="true" exportWarnings="true" includeDirectoryEntries="false" overwrite="true" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>
     <storedRefactorings deprecationInfo="true" structuralOnly="false"/>
     <selectedProjects/>
-    <manifest generateManifest="false" manifestLocation="/Enigma/META-INF/MANIFEST.MF" manifestVersion="1.0" reuseManifest="false" saveManifest="false" usesManifest="true">
+    <manifest generateManifest="false" manifestLocation="/lgmplugin/META-INF/MANIFEST.MF" manifestVersion="1.0" reuseManifest="false" saveManifest="false" usesManifest="true">
         <sealing sealJar="false">
             <packagesToSeal/>
             <packagesToUnSeal/>
         </sealing>
     </manifest>
     <selectedElements exportClassFiles="true" exportJavaFiles="true" exportOutputFolder="false">
-        <file path="/Enigma/.classpath"/>
-        <file path="/Enigma/description.jardesc"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.utility"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.file"/>
-        <folder path="/Enigma/META-INF"/>
-        <file path="/Enigma/COPYING"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.sub"/>
-        <file path="/Enigma/Makefile"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.util"/>
-        <file path="/Enigma/LICENSE"/>
-        <file path="/Enigma/.gitignore"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.messages"/>
-        <file path="/Enigma/README.md"/>
-        <file path="/Enigma/.project"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.other"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.frames"/>
-        <javaElement handleIdentifier="=Enigma/&lt;org.enigma.backend.resources"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.frames"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.other"/>
+        <file path="/lgmplugin/org/enigma/enigma.png"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{SettingsHandler.java"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.util"/>
+        <file path="/lgmplugin/.classpath"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{EnigmaThread.java"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.resources"/>
+        <folder path="/lgmplugin/META-INF"/>
+        <file path="/lgmplugin/COPYING"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.messages"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{TargetHandler.java"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.utility"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.file"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{EnigmaWriter.java"/>
+        <file path="/lgmplugin/LICENSE"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend.sub"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{EnigmaRunner.java"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma.backend"/>
+        <file path="/lgmplugin/README.md"/>
+        <file path="/lgmplugin/org/enigma/syntax.png"/>
+        <javaElement handleIdentifier="=lgmplugin/&lt;org.enigma{EnigmaCli.java"/>
     </selectedElements>
 </jardesc>

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -23,9 +23,7 @@ import static org.lateralgm.main.Util.deRef;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.GraphicsEnvironment;
 import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.Point2D;
@@ -49,9 +47,11 @@ import java.util.WeakHashMap;
 import java.util.zip.DeflaterOutputStream;
 
 import javax.swing.JOptionPane;
+
 import org.enigma.backend.EnigmaStruct;
 import org.enigma.backend.other.Constant;
 import org.enigma.backend.other.Extension;
+import org.enigma.backend.other.Include;
 import org.enigma.backend.resources.Background;
 import org.enigma.backend.resources.Font;
 import org.enigma.backend.resources.GameInformation;
@@ -81,6 +81,7 @@ import org.enigma.backend.util.Polygon;
 import org.enigma.utility.Masker.Mask;
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile;
+import org.lateralgm.file.ResourceList;
 import org.lateralgm.file.iconio.ICOFile;
 import org.lateralgm.main.LGM;
 import org.lateralgm.resources.Background.PBackground;
@@ -88,6 +89,7 @@ import org.lateralgm.resources.Font.PFont;
 import org.lateralgm.resources.GameInformation.PGameInformation;
 import org.lateralgm.resources.GameSettings.PGameSettings;
 import org.lateralgm.resources.GmObject.PGmObject;
+import org.lateralgm.resources.Include.PInclude;
 import org.lateralgm.resources.InstantiableResource;
 import org.lateralgm.resources.Path.PPath;
 import org.lateralgm.resources.Resource;
@@ -169,14 +171,20 @@ public final class EnigmaWriter {
 		// TODO: Populate constants from chosen configuration on the main
 		// toolbar.
 
-		// TODO: Fixme
-		o.includeCount = 0;// i.includes.size();
-		/*
-		 * if (o.includeCount != 0) { o.includes = new Include.ByReference();
-		 * Include[] oil = (Include[]) o.includes.toArray(o.includeCount); for
-		 * (int inc = 0; inc < o.includeCount; inc++) { oil[inc].filepath =
-		 * i.includes.get(inc).filepath; } }
-		 */
+		ResourceList<org.lateralgm.resources.Include> includeList = i.resMap.getList(org.lateralgm.resources.Include.class);
+		org.lateralgm.resources.Include iil[] = includeList.toArray(new org.lateralgm.resources.Include[0]);
+		o.includeCount = includeList.size();
+		if (o.includeCount != 0)
+			{
+			o.includes = new Include.ByReference();
+			Include[] oil = (Include[]) o.includes.toArray(o.includeCount);
+			for (int inc = 0; inc < o.includeCount; inc++)
+				{
+				org.lateralgm.resources.Include ii = iil[inc];
+				oil[inc].filepath = ii.get(PInclude.FILEPATH);
+				}
+			}
+
 		// packages not implemented
 		o.packageCount = 0;
 		// o.packageCount = packages.length;
@@ -201,7 +209,7 @@ public final class EnigmaWriter {
 		{
 		0x1F, 0x74, 0x2F, 0x5C, 0x69, 0x2B, (byte) 0x84,
 		(byte) 0xBB, (byte) 0xE6, (byte) 0xE5, 0x22, 0x23,
-		0x35, 0x55, (byte) 0xE2, (byte) 0x91 
+		0x35, 0x55, (byte) 0xE2, (byte) 0x91
 		},
 		{
 		0x08, (byte) 0xAA, 0x73, (byte) 0xA3, 0x5D, 0x0C,


### PR DESCRIPTION
This request fixes population of the includes to the engine without making a binary compatibility breaking change. I am simply undoing the mistake in ae5f1f8727144b8352a8ca6bfc30fdf68f0ae817 where I commented out the include population rather than fixing it. This should make includes work again in the engine for TKG.
https://github.com/enigma-dev/enigma-dev/issues/709

While I was in here, I also fixed the jar description because we renamed the repo. The repo is no longer under "Enigma" so a fresh clone is downloaded as "lgmplugin/". This makes it easier to build the plugin on a fresh clone.