### PR TITLE
Fix Action Condition Scoping

### DIFF
--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -1204,6 +1204,10 @@ public final class EnigmaWriter {
 				ResourceReference<org.lateralgm.resources.GmObject> apto = act
 						.getAppliesTo();
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF) {
+					if (la.question) {
+						numberOfBraces++;
+						code.append("{\n"); //$NON-NLS-1$
+					}
 					/* Question action using with statement */
 					if (apto == org.lateralgm.resources.GmObject.OBJECT_OTHER)
 						code.append("with (other) "); //$NON-NLS-1$
@@ -1215,7 +1219,10 @@ public final class EnigmaWriter {
 						code.append("{"); //$NON-NLS-1$
 				}
 				if (la.question) {
-					code.append("__if__ = "); //$NON-NLS-1$
+					if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF)
+						code.append("\n__if__ = "); //$NON-NLS-1$
+					else
+						code.append("if "); //$NON-NLS-1$
 					numberOfIfs++;
 				}
 				if (act.isNot())
@@ -1241,8 +1248,8 @@ public final class EnigmaWriter {
 				}
 				if (la.allowRelative)
 					code.append(la.question ? ')' : "\n}"); //$NON-NLS-1$
-				if (la.question)
-					code.append("\nif (__if__)"); //$NON-NLS-1$
+				if (la.question && apto != org.lateralgm.resources.GmObject.OBJECT_SELF)
+					code.append("\nif __if__"); //$NON-NLS-1$
 				code.append(nl);
 
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -1141,6 +1141,7 @@ public final class EnigmaWriter {
 	private static int numberOfIfs = 0; // gm allows multipe else actions after
 										// 1 if, so its important to track the
 										// number
+	private static int numberOfOtherIfs = 0; // gm doesn't inherit applies to scope
 
 	public static String getActionsCode(ActionContainer ac) {
 		final String nl = System.getProperty("line.separator"); //$NON-NLS-1$
@@ -1148,6 +1149,7 @@ public final class EnigmaWriter {
 
 		numberOfBraces = 0;
 		numberOfIfs = 0;
+		numberOfOtherIfs = 0;
 
 		for (Action act : ac.actions) {
 			LibAction la = act.getLibAction();
@@ -1219,9 +1221,10 @@ public final class EnigmaWriter {
 						code.append("{"); //$NON-NLS-1$
 				}
 				if (la.question) {
-					if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF)
+					if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF) {
 						code.append("\n__if__ = "); //$NON-NLS-1$
-					else
+						numberOfOtherIfs++;
+					} else
 						code.append("if "); //$NON-NLS-1$
 					numberOfIfs++;
 				}
@@ -1265,9 +1268,9 @@ public final class EnigmaWriter {
 				code.append("\n}"); //$NON-NLS-1$
 		}
 
-		// use reserved local to store result of conditional expressions
-		// and optimize nested actions with different applies to
-		if (numberOfIfs > 0)
+		// declare reserved local to store result of conditional
+		// expressions with different applies to
+		if (numberOfOtherIfs > 0)
 			code.insert(0, "var __if__ = false\n"); //$NON-NLS-1$
 
 		return code.toString();

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -1215,7 +1215,7 @@ public final class EnigmaWriter {
 							code.append("{"); //$NON-NLS-1$
 				}
 				if (la.question) {
-					code.append("if "); //$NON-NLS-1$
+					code.append("__if__ = "); //$NON-NLS-1$
 					numberOfIfs++;
 				}
 				if (act.isNot())
@@ -1241,6 +1241,8 @@ public final class EnigmaWriter {
 				}
 				if (la.allowRelative)
 					code.append(la.question ? ')' : "\n}"); //$NON-NLS-1$
+				if (la.question)
+					code.append("\nif (__if__)");
 				code.append(nl);
 
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF
@@ -1255,6 +1257,12 @@ public final class EnigmaWriter {
 			for (int i = 0; i < numberOfBraces; i++)
 				code.append("\n}"); //$NON-NLS-1$
 		}
+
+		// use reserved local to store result of conditional expressions
+		// and optimize nested actions with different applies to
+		if (numberOfIfs > 0)
+			code.insert(0, "var __if__ = false\n");
+
 		return code.toString();
 	}
 

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -1204,15 +1204,15 @@ public final class EnigmaWriter {
 				ResourceReference<org.lateralgm.resources.GmObject> apto = act
 						.getAppliesTo();
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF) {
-						/* Question action using with statement */
-						if (apto == org.lateralgm.resources.GmObject.OBJECT_OTHER)
-							code.append("with (other) "); //$NON-NLS-1$
-						else if (apto.get() != null)
-							code.append("with (").append(org.lateralgm.resources.GmObject.refAsInt(apto)).append(") "); //$NON-NLS-1$ //$NON-NLS-2$
-						else
-							code.append("/*null with!*/"); //$NON-NLS-1$
-						if (!la.question)
-							code.append("{"); //$NON-NLS-1$
+					/* Question action using with statement */
+					if (apto == org.lateralgm.resources.GmObject.OBJECT_OTHER)
+						code.append("with (other) "); //$NON-NLS-1$
+					else if (apto.get() != null)
+						code.append("with (").append(org.lateralgm.resources.GmObject.refAsInt(apto)).append(") "); //$NON-NLS-1$ //$NON-NLS-2$
+					else
+						code.append("/*null with!*/"); //$NON-NLS-1$
+					if (!la.question)
+						code.append("{"); //$NON-NLS-1$
 				}
 				if (la.question) {
 					code.append("__if__ = "); //$NON-NLS-1$
@@ -1242,7 +1242,7 @@ public final class EnigmaWriter {
 				if (la.allowRelative)
 					code.append(la.question ? ')' : "\n}"); //$NON-NLS-1$
 				if (la.question)
-					code.append("\nif (__if__)");
+					code.append("\nif (__if__)"); //$NON-NLS-1$
 				code.append(nl);
 
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF
@@ -1261,7 +1261,7 @@ public final class EnigmaWriter {
 		// use reserved local to store result of conditional expressions
 		// and optimize nested actions with different applies to
 		if (numberOfIfs > 0)
-			code.insert(0, "var __if__ = false\n");
+			code.insert(0, "var __if__ = false\n"); //$NON-NLS-1$
 
 		return code.toString();
 	}

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -1204,7 +1204,6 @@ public final class EnigmaWriter {
 				ResourceReference<org.lateralgm.resources.GmObject> apto = act
 						.getAppliesTo();
 				if (apto != org.lateralgm.resources.GmObject.OBJECT_SELF) {
-					if (la.question) {
 						/* Question action using with statement */
 						if (apto == org.lateralgm.resources.GmObject.OBJECT_OTHER)
 							code.append("with (other) "); //$NON-NLS-1$
@@ -1212,15 +1211,8 @@ public final class EnigmaWriter {
 							code.append("with (").append(org.lateralgm.resources.GmObject.refAsInt(apto)).append(") "); //$NON-NLS-1$ //$NON-NLS-2$
 						else
 							code.append("/*null with!*/"); //$NON-NLS-1$
-
-					} else {
-						if (apto == org.lateralgm.resources.GmObject.OBJECT_OTHER)
-							code.append("with (other) {"); //$NON-NLS-1$
-						else if (apto.get() != null)
-							code.append("with (").append(org.lateralgm.resources.GmObject.refAsInt(apto)).append(") {"); //$NON-NLS-1$ //$NON-NLS-2$
-						else
-							code.append("/*null with!*/{"); //$NON-NLS-1$
-					}
+						if (!la.question)
+							code.append("{"); //$NON-NLS-1$
 				}
 				if (la.question) {
 					code.append("if "); //$NON-NLS-1$


### PR DESCRIPTION
This pull request is an attempt to address #54 and make the drag and drop 100% GM compatible. This fixes the test case in #54 so that the red object on the right is destroyed like GM8.1/GMSv1.4 behave.

The first thing I did was simplify the applies to logic to be the same for whether the action is a question or not. The same logic is now used in both cases and the opening `{` brace is simply appended if the action is not a question.

The second thing I did was extract the result of conditional expressions to a reserved local `__if__`, which is only reserved if needed and the compiler should inline anyway. This prevents nested actions from inheriting the scope of their parent actions. This required that I nest the action, its with statement, and its `__if__` assignment inside their own block which starts just before the applies to with.

A condition which applies to the other object will now generate the following:
```cpp
var __if__ = 0;
{
  with(other)
    __if__ = somecondition;
  if (__if__)
    someaction();
}
```
A regular condition that applies to self will generate the same code as always:
```cpp
if (somecondition)
  someaction();
```

I have built a jar of the new plugin for testing prior to merge. This prerelease jar has been used extensively to test for any regressions in existing drag and drop based games.
Download Prerelease Jar: [dragdrop-scope-jar.zip](https://github.com/enigma-dev/lgmplugin/files/3294427/dragdrop-scope-jar.zip)



