### PR TITLE
Fix Wrong Messages Class Imports

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JNA"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="C:/Users/Owner/Desktop/enigma-dev/plugins/shared/jna.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Owner/Documents/projects/enigma-dev/plugins/shared/jna.jar"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/LateralGM"/>
 	<classpathentry kind="src" path=""/>
 	<classpathentry kind="output" path=""/>

--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JNA"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="C:/Users/Owner/Documents/projects/enigma-dev/plugins/shared/jna.jar"/>
+	<classpathentry kind="lib" path="../../projects/enigma-dev/plugins/shared/jna.jar"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/LateralGM"/>
 	<classpathentry kind="src" path=""/>
 	<classpathentry kind="output" path=""/>

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -78,6 +78,7 @@ import org.enigma.backend.sub.View;
 import org.enigma.backend.util.Image;
 import org.enigma.backend.util.Point;
 import org.enigma.backend.util.Polygon;
+import org.enigma.messages.Messages;
 import org.enigma.utility.Masker.Mask;
 import org.lateralgm.components.impl.ResNode;
 import org.lateralgm.file.ProjectFile;
@@ -112,8 +113,6 @@ import org.lateralgm.resources.sub.CharacterRange.PCharacterRange;
 import org.lateralgm.resources.sub.Instance.PInstance;
 import org.lateralgm.resources.sub.Tile.PTile;
 import org.lateralgm.resources.sub.View.PView;
-
-import com.sun.xml.internal.bind.marshaller.Messages;
 
 public final class EnigmaWriter {
 	protected ProjectFile i;

--- a/org/enigma/utility/EnigmaBuildReader.java
+++ b/org/enigma/utility/EnigmaBuildReader.java
@@ -22,6 +22,7 @@ package org.enigma.utility;
 import java.awt.Point;
 import java.io.File;
 
+import org.enigma.messages.Messages;
 import org.lateralgm.file.GmFormatException;
 import org.lateralgm.file.GmStreamDecoder;
 import org.lateralgm.main.LGM;
@@ -29,8 +30,6 @@ import org.lateralgm.resources.GmObject;
 import org.lateralgm.resources.Room;
 import org.lateralgm.resources.sub.Instance;
 import org.lateralgm.resources.sub.Instance.PInstance;
-
-import com.sun.xml.internal.bind.marshaller.Messages;
 
 public final class EnigmaBuildReader
 	{


### PR DESCRIPTION
Just mistakes left over from the original plugin. The mistaken import must have been removed as it was an internal API. Now the plugin can build again.
https://github.com/enigma-dev/enigma-dev/commit/b619add3b7d2cf37d95efa8f402367797418f872