### PR TITLE
Remove Make Directory

### DIFF
--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -146,7 +146,6 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		esh.revertResource();
 
 		rh = LGM.currentFile.resMap.get(EnigmaSettings.class);
-		final String makedir = rh.getResource().getOption("make-directory");
 
 		LGM.addReloadListener(this);
 		SubframeInformer.addSubframeListener(this);
@@ -188,7 +187,6 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 						}
 
 					System.out.println(Messages.getString("EnigmaRunner.INITIALIZING")); //$NON-NLS-1$
-					DRIVER.libSetMakeDirectory(makedir);
 					String err = DRIVER.libInit(ec);
 					if (err != null)
 					{

--- a/org/enigma/backend/EnigmaDriver.java
+++ b/org/enigma/backend/EnigmaDriver.java
@@ -30,8 +30,6 @@ public interface EnigmaDriver extends Library
 			}
 		}
 
-	public void libSetMakeDirectory(String dir);
-
 	public String libInit(EnigmaCallbacks ef);
 
 	public SyntaxError definitionsModified(String wscode, String yaml);


### PR DESCRIPTION
fundies requested this because his equivalent pull request that's already been merged did away with the make directory that the plugin was using.
https://github.com/enigma-dev/enigma-dev/commit/134aea511a3cf852ef0908c31db92b5290457d07

I tried this plugin out with my enigma-dev setup and didn't see any problems with building games.