### PR TITLE
Damn Stop Button

### DIFF
--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -160,8 +160,6 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 			});
 
 		setMenuEnabled(false);
-		//stop.setVisible(false);
-		//stopb.setVisible(false);
 
 		final Thread initthread = new Thread()
 			{
@@ -397,27 +395,27 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 
 	public void populateMenu()
 		{
-		//stopb = new JButton(); //$NON-NLS-1$
-		//stopb.addActionListener(this);
-		//stopb.setToolTipText(Messages.getString("EnigmaRunner.MENU_STOP"));
-		//stopb.setIcon(LGM.getIconForKey("EnigmaPlugin.STOP"));
-		//LGM.tool.add(stopb, 5);
+		stopb = new JButton(); //$NON-NLS-1$
+		stopb.addActionListener(this);
+		stopb.setToolTipText(Messages.getString("EnigmaRunner.MENU_STOP"));
+		stopb.setIcon(LGM.getIconForKey("EnigmaPlugin.STOP"));
+		LGM.tool.add(stopb, 5);
 		runb = new JButton(); //$NON-NLS-1$
 		runb.addActionListener(this);
 		runb.setToolTipText(Messages.getString("EnigmaRunner.MENU_RUN"));
 		runb.setIcon(LGM.getIconForKey("EnigmaPlugin.EXECUTE"));
-		LGM.tool.add(runb, 5);
+		LGM.tool.add(runb, 6);
 		debugb = new JButton(); //$NON-NLS-1$
 		debugb.addActionListener(this);
 		debugb.setToolTipText(Messages.getString("EnigmaRunner.MENU_DEBUG"));
 		debugb.setIcon(LGM.getIconForKey("EnigmaPlugin.DEBUG"));
-		LGM.tool.add(debugb, 6);
+		LGM.tool.add(debugb, 7);
 		compileb = new JButton(); //$NON-NLS-1$
 		compileb.addActionListener(this);
 		compileb.setToolTipText(Messages.getString("EnigmaRunner.MENU_COMPILE"));
 		compileb.setIcon(LGM.getIconForKey("EnigmaPlugin.COMPILE"));
-		LGM.tool.add(compileb, 7);
-		LGM.tool.add(new JToolBar.Separator(), 8);
+		LGM.tool.add(compileb, 8);
+		LGM.tool.add(new JToolBar.Separator(), 9);
 
 		JMenu menu = new GmMenu(Messages.getString("EnigmaRunner.MENU_BUILD")); //$NON-NLS-1$
 		menu.setMnemonic('B');
@@ -445,11 +443,11 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		compile.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("EnigmaRunner.COMPILE")));
 		menu.add(compile);
 		menu.addSeparator();
-		//stop = addItem(Messages.getString("EnigmaRunner.MENU_STOP")); //$NON-NLS-1$
-		//stop.addActionListener(this);
-		//stop.setIcon(LGM.getIconForKey("EnigmaPlugin.STOP"));
-		//stop.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("EnigmaRunner.STOP")));
-		//menu.add(stop);
+		stop = addItem(Messages.getString("EnigmaRunner.MENU_STOP")); //$NON-NLS-1$
+		stop.addActionListener(this);
+		stop.setIcon(LGM.getIconForKey("EnigmaPlugin.STOP"));
+		stop.setAccelerator(KeyStroke.getKeyStroke(Messages.getKeyboardString("EnigmaRunner.STOP")));
+		menu.add(stop);
 		rebuild = addItem(Messages.getString("EnigmaRunner.MENU_REBUILD_ALL")); //$NON-NLS-1$
 		rebuild.addActionListener(this);
 		rebuild.setIcon(LGM.getIconForKey("EnigmaPlugin.REBUILD_ALL"));
@@ -631,10 +629,10 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		run.setEnabled(en);
 		debug.setEnabled(en);
 		design.setEnabled(en);
-		//stop.setEnabled(!en);
+		stop.setEnabled(!en);
 		compile.setEnabled(en);
 		rebuild.setEnabled(en);
-		//stopb.setEnabled(!en);
+		stopb.setEnabled(!en);
 		runb.setEnabled(en);
 		debugb.setEnabled(en);
 		compileb.setEnabled(en);
@@ -664,8 +662,6 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 			populateKeywords();
 
 			setMenuEnabled(true);
-			//stop.setEnabled(false);
-			//stopb.setEnabled(false);
 		}
 	}
 
@@ -674,8 +670,6 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		{
 		if (!assertReady()) return;
 
-		//stop.setEnabled(true);
-		//stopb.setEnabled(true);
 		EnigmaSettings es = LGM.currentFile.resMap.get(EnigmaSettings.class).getResource();
 
 		if (es.targets.get(TargetHandler.COMPILER) == null)
@@ -768,10 +762,7 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		{
 		if (!assertReady()) return;
 		Object s = e.getSource();
-		//if (s == stop || s == stopb) {
-		//	cthread.interrupt();
-		//	setMenuEnabled(true);
-		//}
+		if (s == stop || s == stopb) DRIVER.libStopBuild();
 		if (s == run || s == runb) compile(MODE_RUN);
 		if (s == debug || s == debugb) compile(MODE_DEBUG);
 		if (s == design) compile(MODE_DESIGN);

--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -395,27 +395,28 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 
 	public void populateMenu()
 		{
+		int toolPos = 4; // <- After "Save As" separator.
 		stopb = new JButton(); //$NON-NLS-1$
 		stopb.addActionListener(this);
 		stopb.setToolTipText(Messages.getString("EnigmaRunner.MENU_STOP"));
 		stopb.setIcon(LGM.getIconForKey("EnigmaPlugin.STOP"));
-		LGM.tool.add(stopb, 5);
+		LGM.tool.add(stopb, ++toolPos);
 		runb = new JButton(); //$NON-NLS-1$
 		runb.addActionListener(this);
 		runb.setToolTipText(Messages.getString("EnigmaRunner.MENU_RUN"));
 		runb.setIcon(LGM.getIconForKey("EnigmaPlugin.EXECUTE"));
-		LGM.tool.add(runb, 6);
+		LGM.tool.add(runb, ++toolPos);
 		debugb = new JButton(); //$NON-NLS-1$
 		debugb.addActionListener(this);
 		debugb.setToolTipText(Messages.getString("EnigmaRunner.MENU_DEBUG"));
 		debugb.setIcon(LGM.getIconForKey("EnigmaPlugin.DEBUG"));
-		LGM.tool.add(debugb, 7);
+		LGM.tool.add(debugb, ++toolPos);
 		compileb = new JButton(); //$NON-NLS-1$
 		compileb.addActionListener(this);
 		compileb.setToolTipText(Messages.getString("EnigmaRunner.MENU_COMPILE"));
 		compileb.setIcon(LGM.getIconForKey("EnigmaPlugin.COMPILE"));
-		LGM.tool.add(compileb, 8);
-		LGM.tool.add(new JToolBar.Separator(), 9);
+		LGM.tool.add(compileb, ++toolPos);
+		LGM.tool.add(new JToolBar.Separator(), ++toolPos);
 
 		JMenu menu = new GmMenu(Messages.getString("EnigmaRunner.MENU_BUILD")); //$NON-NLS-1$
 		menu.setMnemonic('B');

--- a/org/enigma/EnigmaWriter.java
+++ b/org/enigma/EnigmaWriter.java
@@ -162,6 +162,10 @@ public final class EnigmaWriter {
 		populateTimelines();
 		populateObjects();
 		populateRooms();
+		
+		// leave if we were interrupted while writing any
+		// resource group above
+		if (Thread.currentThread().isInterrupted()) return;
 
 		// triggers not implemented
 		o.triggerCount = 0;
@@ -371,6 +375,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Sprite.class).toArray(
 				new org.lateralgm.resources.Sprite[0]);
 		for (int s = 0; s < size; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Sprite os = osl[s];
 			org.lateralgm.resources.Sprite is = isl[s];
 
@@ -467,6 +472,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Sound.class).toArray(
 				new org.lateralgm.resources.Sound[0]);
 		for (int s = 0; s < size; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Sound os = osl[s];
 			org.lateralgm.resources.Sound is = isl[s];
 
@@ -507,6 +513,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Background.class).toArray(
 				new org.lateralgm.resources.Background[0]);
 		for (int s = 0; s < size; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Background ob = obl[s];
 			org.lateralgm.resources.Background ib = ibl[s];
 
@@ -542,6 +549,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Path.class).toArray(
 				new org.lateralgm.resources.Path[0]);
 		for (int p = 0; p < size; p++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Path op = opl[p];
 			org.lateralgm.resources.Path ip = ipl[p];
 
@@ -585,6 +593,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Script.class).toArray(
 				new org.lateralgm.resources.Script[0]);
 		for (int s = 0; s < isl.length; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Script oo = osl[s];
 			org.lateralgm.resources.Script io = isl[s];
 
@@ -594,6 +603,7 @@ public final class EnigmaWriter {
 		}
 
 		for (int s = 0; s < qs.size(); s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Script oo = osl[s + isl.length];
 			oo.name = "lib" + qs.get(s).parentId + "_action" + qs.get(s).id; //$NON-NLS-1$ //$NON-NLS-2$
 			oo.id = -s - 2;
@@ -614,6 +624,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Shader.class).toArray(
 				new org.lateralgm.resources.Shader[0]);
 		for (int s = 0; s < isl.length; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Shader oo = osl[s];
 			org.lateralgm.resources.Shader io = isl[s];
 
@@ -667,6 +678,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Font.class).toArray(
 				new org.lateralgm.resources.Font[0]);
 		for (int f = 1; f < size; f++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Font of = ofl[f];
 			org.lateralgm.resources.Font ifont = ifl[f - 1];
 
@@ -778,6 +790,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.Timeline.class).toArray(
 				new org.lateralgm.resources.Timeline[0]);
 		for (int t = 0; t < size; t++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Timeline ot = otl[t];
 			org.lateralgm.resources.Timeline it = itl[t];
 
@@ -810,6 +823,7 @@ public final class EnigmaWriter {
 				org.lateralgm.resources.GmObject.class).toArray(
 				new org.lateralgm.resources.GmObject[0]);
 		for (int s = 0; s < size; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			GmObject oo = ool[s];
 			org.lateralgm.resources.GmObject io = iol[s];
 
@@ -888,6 +902,7 @@ public final class EnigmaWriter {
 		org.lateralgm.resources.Room[] irl = irooms
 				.toArray(new org.lateralgm.resources.Room[0]);
 		for (int s = 0; s < size; s++) {
+			if (Thread.currentThread().isInterrupted()) return;
 			Room or = orly[s];
 			org.lateralgm.resources.Room is = irl[s];
 
@@ -989,6 +1004,7 @@ public final class EnigmaWriter {
 
 			or.instanceCount = ri.size();
 			if (or.instanceCount != 0) {
+				if (Thread.currentThread().isInterrupted()) return;
 				or.instances = new Instance.ByReference();
 				Instance[] oil = (Instance[]) or.instances.toArray(ri.size());
 				int i = 0;
@@ -1051,6 +1067,7 @@ public final class EnigmaWriter {
 
 			or.tileCount = is.tiles.size();
 			if (or.tileCount != 0) {
+				if (Thread.currentThread().isInterrupted()) return;
 				or.tiles = new Tile.ByReference();
 				Tile[] otl = (Tile[]) or.tiles.toArray(or.tileCount);
 				for (int t = 0; t < otl.length; t++) {

--- a/org/enigma/backend/EnigmaDriver.java
+++ b/org/enigma/backend/EnigmaDriver.java
@@ -30,6 +30,8 @@ public interface EnigmaDriver extends Library
 			}
 		}
 
+	public void libStopBuild();
+
 	public String libInit(EnigmaCallbacks ef);
 
 	public SyntaxError definitionsModified(String wscode, String yaml);

--- a/org/enigma/messages/messages.properties
+++ b/org/enigma/messages/messages.properties
@@ -22,6 +22,7 @@ EnigmaPlugin.SELALL=Select All
 EnigmaReader.UNKNOWN_VERSION=Unsupported version {0}
 EnigmaReader.UNKNOWN_ACTION= Unsupported action type {0}
 
+EnigmaRunner.BUILD_STOPPED=Build Stopped
 EnigmaRunner.BUTTON_SYNTAX=Syntax
 EnigmaRunner.BUTTON_SYNTAX_TIP=Syntax
 EnigmaRunner.CALLING=Calling compiler.


### PR DESCRIPTION
This is a friend of the ENIGMA pull request which adds the DLL method to signal the build to stop.
https://github.com/enigma-dev/enigma-dev/pull/2068

All I am doing is bringing back the stop button that I had already added to the UI in the past. I had to clearly add `libStopBuild()` DLL method to the driver too for it to be loaded. I removed some miscellaneous locations I was enabling and disabling the stop button because they were unnecessary, however, the button still needs to be enabled at a specific point, when the `ide_dia_clear` callback is fired. It should also be disabled as soon as it is pressed by the user.