### PR TITLE
Fix OpenFile Callback Race Condition

### DIFF
--- a/org/enigma/backend/EnigmaCallbacks.java
+++ b/org/enigma/backend/EnigmaCallbacks.java
@@ -134,27 +134,14 @@ public class EnigmaCallbacks extends Structure
 						{
 						EnigmaRunner.addDefaultExceptionHandler();
 						InputStream in = null;
-						while (in == null)
+						try
 							{
-							try
-								{
-								in = new FileInputStream(file);
-								}
-							catch (FileNotFoundException e)
-								{
-								if (!running)
-									{
-									EnigmaRunner.showDefaultExceptionHandler(e);
-									return;
-									}
-								try
-									{
-									Thread.sleep(100);
-									}
-								catch (InterruptedException e1)
-									{
-									}
-								}
+							in = new FileInputStream(file);
+							}
+						catch (FileNotFoundException e)
+							{
+							if (!running) return;
+							EnigmaRunner.showDefaultExceptionHandler(e);
 							}
 						try
 							{

--- a/org/enigma/backend/EnigmaCallbacks.java
+++ b/org/enigma/backend/EnigmaCallbacks.java
@@ -133,17 +133,7 @@ public class EnigmaCallbacks extends Structure
 					public void run()
 						{
 						EnigmaRunner.addDefaultExceptionHandler();
-						InputStream in = null;
-						try
-							{
-							in = new FileInputStream(file);
-							}
-						catch (FileNotFoundException e)
-							{
-							if (!running) return;
-							EnigmaRunner.showDefaultExceptionHandler(e);
-							}
-						try
+						try (InputStream in = new FileInputStream(file))
 							{
 							StringBuilder sb = new StringBuilder();
 							while (true)
@@ -168,6 +158,7 @@ public class EnigmaCallbacks extends Structure
 									}
 								else
 									{
+									if (!running) return;
 									try
 										{
 										Thread.sleep(100);
@@ -178,7 +169,6 @@ public class EnigmaCallbacks extends Structure
 									}
 								}
 							out.append(sb.toString() + '\n');
-							in.close();
 							}
 						catch (IOException e)
 							{

--- a/org/enigma/backend/EnigmaCallbacks.java
+++ b/org/enigma/backend/EnigmaCallbacks.java
@@ -158,7 +158,7 @@ public class EnigmaCallbacks extends Structure
 									}
 								else
 									{
-									if (!running) return;
+									if (!running) break;
 									try
 										{
 										Thread.sleep(100);

--- a/org/enigma/backend/EnigmaCallbacks.java
+++ b/org/enigma/backend/EnigmaCallbacks.java
@@ -122,12 +122,14 @@ public class EnigmaCallbacks extends Structure
 
 	public static class OpenFile extends OutputHolder implements Callback
 		{
-		static boolean running = true;
+		// ENIGMA is still redirecting output, and it's not safe
+		// to finish reading yet if we encounter an EOF.
+		static boolean enigma_redirecting = true;
 
 		public void callback(final String filename)
 			{
 			final File file = new File(filename);
-			running = true;
+			enigma_redirecting = true;
 			new Thread()
 				{
 					public void run()
@@ -145,7 +147,7 @@ public class EnigmaCallbacks extends Structure
 									{
 									data = new byte[size];
 									size = in.read(data,0,size);
-									if (size == -1) break;
+									if (size == -1 && !enigma_redirecting) break; // EOF
 									sb.append(new String(data,0,size,"UTF-8")); //$NON-NLS-1$
 									int p = sb.indexOf("\n"); //$NON-NLS-1$
 									while (p != -1)
@@ -158,7 +160,6 @@ public class EnigmaCallbacks extends Structure
 									}
 								else
 									{
-									if (!running) break;
 									try
 										{
 										Thread.sleep(100);
@@ -184,7 +185,7 @@ public class EnigmaCallbacks extends Structure
 		@SuppressWarnings("static-method")
 		public void callback()
 			{
-			OpenFile.running = false;
+			OpenFile.enigma_redirecting = false;
 			}
 		}
 


### PR DESCRIPTION
I finally found the source of all those race conditions in the output frame that cause text to be duplicated multiple times after a few builds. This is a multipart problem and this is just the first of the issues.

IsmAvatar added a boolean to the `OpenFile` IDE callback which spawns the output reading thread, but checked it in the wrong spot. Since it's only checked initially when opening the input stream, CloseFile's request is completely ignored, and the output threads keep running after every single build!
https://github.com/enigma-dev/enigma-dev/commit/922dc772e3eca5e418905dec5349101140e512e0#diff-4295f6906dbadc02e4aad6020fea7d2bR103

Also, the loop added there is infinite in the error case that the file can't be opened! Rusky agrees with me to get rid of all that business. So I'm throwing that out, using a try-with-resources on the input stream so that's it properly closed, and checking the running boolean when there's no data available just before the thread goes to sleep.

I know this is safe because if we look at how ENIGMA actually calls these callbacks, it does in fact create the output file before firing the IDE callback.
https://github.com/enigma-dev/enigma-dev/blob/6fffee88ae7fd9c7d6e0e7ac17cc79d97c541d17/CompilerSource/compiler/compile.cpp#L654

I also had to clarify the behavior of the CloseFile callback with a comment based on the way it's being used. We want the IDE to catch all the output ENIGMA had redirected to it, so it would not be safe for us to finish reading before we've reached an EOF.
https://github.com/enigma-dev/enigma-dev/blob/6fffee88ae7fd9c7d6e0e7ac17cc79d97c541d17/CompilerSource/compiler/compile.cpp#L667

