### PR TITLE
Update EGM Progress Dialog API

### DIFF
--- a/org/enigma/file/EFileReader.java
+++ b/org/enigma/file/EFileReader.java
@@ -49,7 +49,6 @@ import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
-import javax.swing.JProgressBar;
 import javax.swing.filechooser.FileView;
 
 import org.enigma.EnigmaRunner;
@@ -551,9 +550,8 @@ public class EFileReader
 	public static void readEgmFile(EProjectFile f, ProjectFile gf, ResNode root) throws IOException
 		{
 		gf.format = EFileWriter.FLAVOR_EGM;
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(f.getEntries().size());
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
+		int workSize = f.getEntries().size();
+		LGM.initProgressDialog(0, workSize, Messages.getString("ProgressDialog.EGM_LOADING"));
 
 		LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
 		readNodeChildren(f,gf,root,null,new String());
@@ -564,7 +562,7 @@ public class EFileReader
 		while (!postpone.isEmpty())
 			postpone.remove().invoke();
 
-		LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
+		LGM.setProgress(workSize,Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	// Workhorse methods
@@ -624,6 +622,7 @@ public class EFileReader
 	public static void processEntries(EProjectFile f, ProjectFile gf, ResNode parent,
 			List<EgmEntry> entries, String dir) throws IOException
 		{
+		int i = 0;
 		for (EgmEntry e : entries)
 			{
 			String entry = e.name;
@@ -647,7 +646,7 @@ public class EFileReader
 				else
 					System.out.println("Extraneous TOC entry: " + e.name + " (" + e.kind + ")");
 				}
-			LGM.setProgress(LGM.getProgressDialogBar().getValue() + 1,Messages.getString("ProgressDialog.ENTRIES"));
+			LGM.setProgress(++i,Messages.getString("ProgressDialog.ENTRIES"));
 			}
 		}
 

--- a/org/enigma/file/EFileWriter.java
+++ b/org/enigma/file/EFileWriter.java
@@ -33,8 +33,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import javax.imageio.ImageIO;
-import javax.swing.JProgressBar;
-
 import org.enigma.EnigmaRunner;
 import org.enigma.backend.EnigmaSettings;
 import org.enigma.messages.Messages;
@@ -346,9 +344,7 @@ public class EFileWriter
 
 	public static void writeEProjectFile(EGMOutputStream os, ProjectFile gf, ResNode tree) throws IOException
 		{
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(tree.getChildCount());
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
+		LGM.initProgressDialog(0, tree.getChildCount(), Messages.getString("ProgressDialog.EGM_LOADING"));
 
 		LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
 		writeNodeChildren(os,gf,tree,new ArrayList<String>());
@@ -356,7 +352,7 @@ public class EFileWriter
 		EnigmaSettingsWriter esw = new EnigmaSettingsWriter();
 		esw.write(os, gf, "Enigma Settings", new ArrayList<String>());
 
-		LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
+		LGM.setProgress(tree.getChildCount(),Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	// Workhorse methods
@@ -378,7 +374,9 @@ public class EFileWriter
 			{
 			ResNode child = ((ResNode) node.getChildAt(i));
 
-			if (child.status == ResNode.STATUS_SECONDARY)
+			if (child.status == ResNode.STATUS_PRIMARY)
+				LGM.setProgress(i,Messages.getString("ProgressDialog.ENTRIES"));
+			else if (child.status == ResNode.STATUS_SECONDARY)
 				{
 				writeResource(os,gf,child,dir);
 				}
@@ -392,8 +390,6 @@ public class EFileWriter
 				writeNodeChildren(os,gf,child,newDir);
 				}
 			}
-		if (node.status == ResNode.STATUS_PRIMARY)
-			LGM.setProgress(LGM.getProgressDialogBar().getValue()+1,Messages.getString("ProgressDialog.ENTRIES"));
 		}
 
 	/**


### PR DESCRIPTION
I changed the progress dialog API in LGM in such a way that the progress dialog bar is no longer directly accessible.
https://github.com/IsmAvatar/LateralGM/commit/becbc889034f4c08222d3671f5bf722bb0559dd6
However, the plugin EGM reader/writer is still using the old API, so this pull request is just me updating it to the new API.