### PR TITLE
Disable Old EGM

### DIFF
--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -341,8 +341,8 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		FileChooser.readers.add(io);
 		FileChooser.writers.add(io);
 
-		Listener.getInstance().fc.addOpenFilters(io);
-		Listener.getInstance().fc.addSaveFilters(io);
+		//Listener.getInstance().fc.addOpenFilters(io);
+		//Listener.getInstance().fc.addSaveFilters(io);
 
 		LGM.addPluginResource(new EnigmaSettingsPluginResource());
 		}

--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -341,6 +341,10 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 		FileChooser.readers.add(io);
 		FileChooser.writers.add(io);
 
+		// TODO: Disabled until somebody can figure out what the HELL is going on!
+		// Old EGM was a bad mix of binary and text serialization that led to extreme
+		// frustrations, and it should not be enabled until it is cleaned up,
+		// converted to text, versions the binaries, or is replaced with the new libEGM
 		//Listener.getInstance().fc.addOpenFilters(io);
 		//Listener.getInstance().fc.addSaveFilters(io);
 


### PR DESCRIPTION
This follows from #79, #50, and all the other EGM issues. The format was never finalized, it mixed binary with text, and remains completely unstable. We should hide it from the open and save dialogs of LGM so that people stop creating new EGMs when it just leads to frustration. It's not even possible currently to open a new EGM right after you create it, so there's no point in showing it at all in the frontend.

EGM can be enabled again later if somebody wants to rework the old EGM format to either version those binaries or convert it to text/yaml. The best idea would be to just rewrite it or use the new libEGM directly.