### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# competition for Thundercleese
+notifications:
+  irc: "chat.freenode.net#enigma"
+# don't build "feature" branches
+branches:
+  only:
+    - "master"
+# obviously this is java duh
+language: java
+
+os: linux
+dist: xenial
+
+script:
+  - make
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,9 @@ os: linux
 dist: xenial
 
 script:
+  - cd ..
+  - git clone --recursive https://github.com/IsmAvatar/LateralGM.git
+  - cd $TRAVIS_REPO_SLUG
+  - curl -o jna.jar https://enigma-dev.org/bin/jna.jar
   - make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ os: linux
 dist: xenial
 
 script:
-  - cd ..
-  - git clone --recursive https://github.com/IsmAvatar/LateralGM.git
-  - cd $TRAVIS_REPO_SLUG
+  - git clone --recursive https://github.com/IsmAvatar/LateralGM.git ../LateralGM
   - curl -o jna.jar https://enigma-dev.org/bin/jna.jar
   - make
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM:modules/joshedit/src/main/java:modules/joshedit/src/main/resources
+JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM:../LateralGM/modules/joshedit/src/main/java:../LateralGM/modules/joshedit/src/main/resources
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM/org/lateralgm/main
+JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:lateralgm.jar
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java
-        $(JC) $(JFLAGS) $*.java
+	$(JC) $(JFLAGS) $*.java
 
 JAVA_FILES = $(shell find org -name "*.java")
 JAR_INC_FILES = $(shell find org -type f \( -not -wholename '*/.git/*' \) -a \( -not -name "*.java" \))
@@ -14,11 +14,11 @@ default: classes jar
 classes: $(BASE_CLASSES)
 
 clean:
-        find org/enigma -name "*.class" -exec rm {} \;
-        rm -f $(OUTPUT_FILE)
+	find org/enigma -name "*.class" -exec rm {} \;
+	rm -f $(OUTPUT_FILE)
 
 jar: $(BASE_CLASSES)
-        @echo JAR $(OUTPUT_FILE)
-        @jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING LICENSE $(subst $$,\$$,$(JAR_INC_FILES))
+	@echo JAR $(OUTPUT_FILE)
+	@jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING LICENSE $(subst $$,\$$,$(JAR_INC_FILES))
 
 .PHONY: clean jar default classes

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:../plugins/shared/jna.jar:../LateralGM/lateralgm.jar
+JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:lateralgm.jar
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:../plugins/shared/jna.jar:../lgm16b4.jar:/usr/share/java/eclipse-ecj.jar:/usr/share/java/ecj.jar
+JFLAGS = -source 1.7 -target 1.7 -cp .:../plugins/shared/jna.jar:../LateralGM/lateralgm.jar
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
-JC = ecj -1.6 -nowarn -cp .
-JFLAGS = -cp ../plugins/shared/jna.jar:../lgm16b4.jar:/usr/share/java/eclipse-ecj.jar:/usr/share/java/ecj.jar
-OUTPUT_FILE = ../plugins/enigma.jar
+JC = javac
+JFLAGS = -source 1.7 -target 1.7 -cp .:../plugins/shared/jna.jar:../lgm16b4.jar:/usr/share/java/eclipse-ecj.jar:/usr/share/java/ecj.jar
+OUTPUT_FILE = enigma.jar
 
-.SUFFIXES: .java .class
-
-.java.class:
+%.class: %.java
         $(JC) $(JFLAGS) $*.java
 
 JAVA_FILES = $(shell find org -name "*.java")
-JAR_INC_FILES = $(shell find org -type f \( -not -wholename '*/.git/*' \) -a \( -not -name "*.java" \) | sed 's/\$$/\\\$$/g')
+JAR_INC_FILES = $(shell find org -type f \( -not -wholename '*/.git/*' \) -a \( -not -name "*.java" \))
+BASE_CLASSES = $(JAVA_FILES:.java=.class)
 
 default: classes jar
 
-classes: $(JAVA_FILES:.java=.class)
+classes: $(BASE_CLASSES)
 
 clean:
         find org/enigma -name "*.class" -exec rm {} \;
         rm -f $(OUTPUT_FILE)
 
-jar:
-        @jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING LICENSE $(JAR_INC_FILES)
+jar: $(BASE_CLASSES)
+        @echo JAR $(OUTPUT_FILE)
+        @jar cfm $(OUTPUT_FILE) META-INF/MANIFEST.MF COPYING LICENSE $(subst $$,\$$,$(JAR_INC_FILES))
+
+.PHONY: clean jar default classes

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:lateralgm.jar
+JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM/org/lateralgm/main
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 JC = javac
-JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM
+JFLAGS = -source 1.7 -target 1.7 -cp .:jna.jar:../LateralGM:modules/joshedit/src/main/java:modules/joshedit/src/main/resources
 OUTPUT_FILE = enigma.jar
 
 %.class: %.java

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-LateralGM Plugin
+LateralGM Plugin ![Travis CI Build Status](https://travis-ci.org/enigma-dev/lgmplugin.svg?branch=master)
 =========
 
 Java based plugin that enables [LateralGM](https://github.com/IsmAvatar/LateralGM) to compile games using [ENIGMA](https://github.com/enigma-dev/enigma-dev). If you are having issues or receiving error messages related to the plugin please visit the ENIGMA wiki and read the [troubleshooting page](http://enigma-dev.org/docs/Wiki/Troubleshoot) before posting new issues.

--- a/org/enigma/file/EFileReader.java
+++ b/org/enigma/file/EFileReader.java
@@ -550,11 +550,6 @@ public class EFileReader
 	public static void readEgmFile(EProjectFile f, ProjectFile gf, ResNode root) throws IOException
 		{
 		gf.format = EFileWriter.FLAVOR_EGM;
-		//JProgressBar progressBar = LGM.getProgressDialogBar();
-		//progressBar.setMaximum(f.getEntries().size());
-		//LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
-
-		//LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
 		readNodeChildren(f,gf,root,null,new String());
 
 		readResource(f,gf,null,EnigmaSettings.class,
@@ -562,8 +557,6 @@ public class EFileReader
 
 		while (!postpone.isEmpty())
 			postpone.remove().invoke();
-
-		//LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	// Workhorse methods

--- a/org/enigma/file/EFileReader.java
+++ b/org/enigma/file/EFileReader.java
@@ -639,7 +639,6 @@ public class EFileReader
 				else
 					System.out.println("Extraneous TOC entry: " + e.name + " (" + e.kind + ")");
 				}
-			//LGM.setProgress(LGM.getProgressDialogBar().getValue() + 1,Messages.getString("ProgressDialog.ENTRIES"));
 			}
 		}
 

--- a/org/enigma/file/EFileReader.java
+++ b/org/enigma/file/EFileReader.java
@@ -49,7 +49,6 @@ import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
-import javax.swing.JProgressBar;
 import javax.swing.filechooser.FileView;
 
 import org.enigma.EnigmaRunner;
@@ -551,11 +550,11 @@ public class EFileReader
 	public static void readEgmFile(EProjectFile f, ProjectFile gf, ResNode root) throws IOException
 		{
 		gf.format = EFileWriter.FLAVOR_EGM;
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(f.getEntries().size());
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
+		//JProgressBar progressBar = LGM.getProgressDialogBar();
+		//progressBar.setMaximum(f.getEntries().size());
+		//LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
 
-		LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
+		//LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
 		readNodeChildren(f,gf,root,null,new String());
 
 		readResource(f,gf,null,EnigmaSettings.class,
@@ -564,7 +563,7 @@ public class EFileReader
 		while (!postpone.isEmpty())
 			postpone.remove().invoke();
 
-		LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
+		//LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	// Workhorse methods
@@ -647,7 +646,7 @@ public class EFileReader
 				else
 					System.out.println("Extraneous TOC entry: " + e.name + " (" + e.kind + ")");
 				}
-			LGM.setProgress(LGM.getProgressDialogBar().getValue() + 1,Messages.getString("ProgressDialog.ENTRIES"));
+			//LGM.setProgress(LGM.getProgressDialogBar().getValue() + 1,Messages.getString("ProgressDialog.ENTRIES"));
 			}
 		}
 

--- a/org/enigma/file/EFileWriter.java
+++ b/org/enigma/file/EFileWriter.java
@@ -33,7 +33,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import javax.imageio.ImageIO;
-import javax.swing.JProgressBar;
 
 import org.enigma.EnigmaRunner;
 import org.enigma.backend.EnigmaSettings;
@@ -346,17 +345,10 @@ public class EFileWriter
 
 	public static void writeEProjectFile(EGMOutputStream os, ProjectFile gf, ResNode tree) throws IOException
 		{
-		JProgressBar progressBar = LGM.getProgressDialogBar();
-		progressBar.setMaximum(tree.getChildCount());
-		LGM.setProgressTitle(Messages.getString("ProgressDialog.EGM_LOADING"));
-
-		LGM.setProgress(0,Messages.getString("ProgressDialog.ENTRIES"));
 		writeNodeChildren(os,gf,tree,new ArrayList<String>());
 
 		EnigmaSettingsWriter esw = new EnigmaSettingsWriter();
 		esw.write(os, gf, "Enigma Settings", new ArrayList<String>());
-
-		LGM.setProgress(progressBar.getMaximum(),Messages.getString("ProgressDialog.FINISHED"));
 		}
 
 	// Workhorse methods
@@ -392,8 +384,6 @@ public class EFileWriter
 				writeNodeChildren(os,gf,child,newDir);
 				}
 			}
-		if (node.status == ResNode.STATUS_PRIMARY)
-			LGM.setProgress(LGM.getProgressDialogBar().getValue()+1,Messages.getString("ProgressDialog.ENTRIES"));
 		}
 
 	/**


### PR DESCRIPTION
This follows the LateralGM change that got Travis CI working using the already existing Makefile. It avoids destroying the git blame to restructure the repo like Apache Maven.
https://github.com/IsmAvatar/LateralGM/pull/507

The Travis script has to recursively clone LateralGM next to where the plugin gets checked out so that it can find all the classes it's referring to and everything. It also has to download `jna.jar` from Josh's cache on the website, because we use a specific JNA version and have never depended on the system JNA which #28 shows has issues.

I made the same changes to the Makefile as was done for LGM, which means using the regular standard Java compiler instead of the Eclipse Java compiler. Like I said when I merged it over there, if people want to build with the ECJ, they can just build it with Eclipse. The Makefile should be for people looking to build without Eclipse.

Also I had to remove that damn #77 progress bar because it won't compile without it. The thing wasn't even thread safe. I didn't want to enable the Makefile to build with errors. We just disabled EGM in #80 & #83 anyway, so just get rid of it!