### PR TITLE
Enable Stop API

### DIFF
--- a/org/enigma/EnigmaRunner.java
+++ b/org/enigma/EnigmaRunner.java
@@ -193,6 +193,13 @@ public class EnigmaRunner implements ActionListener,SubframeListener,ReloadListe
 						return;
 					}
 
+					try {
+						DRIVER.libEnableStopAPI();
+					} catch (UnsatisfiedLinkError ule) {
+						// enigma only added this recently
+						// sink the error for now
+					}
+
 					while (LGM.LOADING_PROJECT) {
 						try {
 							Thread.sleep(100);

--- a/org/enigma/backend/EnigmaDriver.java
+++ b/org/enigma/backend/EnigmaDriver.java
@@ -30,6 +30,7 @@ public interface EnigmaDriver extends Library
 			}
 		}
 
+	public void libEnableStopAPI();
 	public void libStopBuild();
 
 	public String libInit(EnigmaCallbacks ef);


### PR DESCRIPTION
This follows from the ENIGMA side pull request which is requiring the stop API to be enabled prior to using it.
https://github.com/enigma-dev/enigma-dev/pull/2103

I tested and it seems to work enabling it directly after the driver initializes the library. Seems like an appropriate time. I also made it a silent error, like the stop button itself, if the method isn't found to make life a little easier.
