### PR TITLE
Fix Keywords Build Error

### DIFF
--- a/org/enigma/frames/EnigmaSettingsHandler.java
+++ b/org/enigma/frames/EnigmaSettingsHandler.java
@@ -1002,7 +1002,6 @@ public class EnigmaSettingsHandler implements ActionListener,FocusListener,Popup
 						{
 						res.commitToDriver(EnigmaRunner.DRIVER);
 						EnigmaRunner.populateKeywords();
-						CodeTextArea.updateKeywords();
 						}
 					}
 				cfDef = null;


### PR DESCRIPTION
This pull request only fixes a build error just introduced by LGM 1.8.216 and does not fix the longstanding regression. In https://github.com/IsmAvatar/LateralGM/commit/4cac51b94cf9ee58758f0d798548e3a4e8d0f01a I deleted the old code for updating the keywords, which is no longer needed as keywords are encapsulated in a token marker class Josh wrote. The reason keywords do not currently update has to do with the token marker cache me and Josh added in https://github.com/IsmAvatar/LateralGM/commit/7887efb01ca375e148cfd10ad14491c0df865563 to LateralGM. The keywords issue can be fixed later on, but for now this just fixes the plugin build error.