### PR TITLE
Fix Empty YAML Content Nodes

### DIFF
--- a/org/enigma/TargetHandler.java
+++ b/org/enigma/TargetHandler.java
@@ -415,8 +415,10 @@ public final class TargetHandler
 		YamlNode n = ((YamlNode) e);
 		for (YamlElement el : n.chronos)
 			{
+			String value = ((YamlContent) el).getValue();
+			if (value == null) continue;
 			Set<String> dep = new HashSet<String>();
-			for (String s : SPLITTER.split(((YamlContent) el).getValue().toLowerCase()))
+			for (String s : SPLITTER.split(value.toLowerCase()))
 				if (!s.isEmpty()) dep.add(s);
 			map.put(el.name,dep);
 			}

--- a/org/enigma/file/YamlParser.java
+++ b/org/enigma/file/YamlParser.java
@@ -106,14 +106,12 @@ public class YamlParser
 		// Implicitly behave as a string
 		public String toString()
 			{
-			if (rawValue == null) return "";
 			return rawValue;
 			}
 
 		public String getValue()
 			{
 			if (escValue == null) escValue = escape(rawValue);
-			if (escValue == null) return "";
 			return escValue;
 			}
 

--- a/org/enigma/file/YamlParser.java
+++ b/org/enigma/file/YamlParser.java
@@ -106,12 +106,14 @@ public class YamlParser
 		// Implicitly behave as a string
 		public String toString()
 			{
+			if (rawValue == null) return "";
 			return rawValue;
 			}
 
 		public String getValue()
 			{
 			if (escValue == null) escValue = escape(rawValue);
+			if (escValue == null) return "";
 			return escValue;
 			}
 


### PR DESCRIPTION
Aj ran into this problem working on his new sound system when he specified no build systems for represents.
```
Represents:
    Build-platforms: 
```
This gave him an exception because the YAML parser would return null instead of an empty string.
```
java.lang.NullPointerException: Cannot invoke "String.toLowerCase()" because the return value of "org.enigma.file.YamlParser$YamlContent.getValue()" is null
    at org.enigma.TargetHandler.populateMap(TargetHandler.java:419)
    at org.enigma.TargetHandler.findTargets(TargetHandler.java:372)
    at org.enigma.TargetHandler.load(TargetHandler.java:70)
```
Depends and represents were the only two that relied on the map method.
https://github.com/enigma-dev/lgmplugin/blob/39f981d82d1e0182b7d12ab80bfae2fed6fddfe7/org/enigma/TargetHandler.java#L363

I chose to fix this the canonical Java way instead of at the callsite by having `YamlContent` return an empty string instead of null when its getters are called. Other Java APIs (such as for XML) may throw exceptions when they hit reading problems, but nobody that I know ever returns null instead of an empty String.
